### PR TITLE
Eliminated deprecated and dependencies, as they needlessly clutter the README page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ ros2 launch l3xz control.py
 * [l3xz_head_ctrl](https://github.com/107-systems/l3xz_head_ctrl): Head controller for the L3X-Z electric/hydraulic hexapod robot.
 * [l3xz_hydraulic_ctrl](https://github.com/107-systems/l3xz_hydraulic_ctrl): Hydraulic controller for the L3X-Z electric/hydraulic hexapod robot.
 * [l3xz_frontend](https://github.com/107-systems/l3xz_frontend): Web based frontend for L3X-Z.
-* [l3xz_frontend_base](https://github.com/107-systems/l3xz_frontend_base): Fundamental functionalities for frontends using roslibjs.
 ##### Firmware
 * [l3xz-aux-ctrl-firmware](https://github.com/107-systems/l3xz-aux-ctrl-firmware): Firmware for the [L3X-Z](https://github.com/107-systems/l3xz) auxiliary controller ([OpenCyphalPicoBase](https://github.com/generationmake/OpenCyphalPicoBase)).
 * [l3xz-leg-ctrl-firmware](https://github.com/107-systems/l3xz-leg-ctrl-firmware): Firmware for the [L3X-Z](https://github.com/107-systems/l3xz) leg controller ([l3xz-leg-ctrl-hardware](https://github.com/107-systems/l3xz-leg-ctrl-hardware)).
@@ -72,15 +71,10 @@ ros2 launch l3xz control.py
 * [PowerPole-Distributor-12](https://github.com/107-systems/PowerPole-Distributor-12): 12 - way power distribution board with Anderson PowerPole® connectors.
 ##### CAD
 * [l3xz-cad](https://github.com/107-systems/l3xz-cad): L3X-Z Hexapod hardware design files (3D model, printed parts, etc.).
-##### Dependencies
-* [libdynamixelplusplus](https://github.com/107-systems/libdynamixelplusplus): C++17 wrapper for the Robotis Dynamixel servo protocol.
-* [orocos-kdl](https://github.com/107-systems/orocos-kdl-debian): Prebuilt Debian package for `aarch64-linux-gnu` and `arm-linux-gnueabihf`.
 ##### "Dragonbeard" pan/tilt color/thermal imaging head
 * **ROS**: [l3xz_openmv_camera](https://github.com/107-systems/l3xz_openmv_camera): ROS driver for [OpenMV](https://openmv.io/) camera.
 * **CAD**: [l3xz-hw-pan-tilt-head](https://github.com/107-systems/l3xz-hw-pan-tilt-head): CAD files for L3X-Z's pan/tilt color/thermal imaging head.
 * **Docker**: [l3xz-sw-pan-tilt-head](https://github.com/107-systems/l3xz-sw-pan-tilt-head): Software bundle for deployment on the Raspberry Pi Zero 2 of the [pan/tilt head](https://github.com/107-systems/l3xz-hw-pan-tilt-head).
-##### Deprecated
-* [l3xz_sweep_scanner](https://github.com/107-systems/l3xz_sweep_scanner): ROS driver for Scanse Sweep 360° 2D LIDAR. **Sensor no longer used in L3X-Z.**
 
 ### Configuration
 #### Network Configuration


### PR DESCRIPTION
- Dependencies are installed when cloning --recursive.
- Deprecated code is simply no longer used.